### PR TITLE
Normalize Monty NPS

### DIFF
--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -811,7 +811,7 @@ class RunDb:
                     nps += concurrency * task["worker_info"]["nps"]
                     if task["worker_info"]["nps"] != 0:
                         games_per_minute += (
-                            (task["worker_info"]["nps"] / 136622)
+                            (task["worker_info"]["nps"] / 368174)
                             * (60.0 / estimate_game_duration(run["args"]["tc"]))
                             * (
                                 int(task["worker_info"]["concurrency"])

--- a/server/utils/delta_update_users.py
+++ b/server/utils/delta_update_users.py
@@ -48,7 +48,7 @@ def compute_games_rates(rundb, info_tuple):
     # use the reference core nps, also set in rundb.py and games.py
     for machine in rundb.get_machines():
         games_per_hour = (
-            (machine["nps"] / 136622)
+            (machine["nps"] / 368174)
             * (3600.0 / estimate_game_duration(machine["run"]["args"]["tc"]))
             * (int(machine["concurrency"]) // machine["run"]["args"].get("threads", 1))
         )

--- a/worker/games.py
+++ b/worker/games.py
@@ -1140,16 +1140,16 @@ def run_games(
     if run_errors:
         raise RunException("\n".join(run_errors))
 
-    if base_nps < 45541 / (1 + math.tanh((worker_concurrency - 1) / 8)):
+    if base_nps < 122725 / (1 + math.tanh((worker_concurrency - 1) / 8)):
         raise FatalException(
             "This machine is too slow ({} nps / thread) to run fishtest effectively - sorry!".format(
                 base_nps
             )
         )
-    # fishtest with Stockfish 11 had 1.6 Mnps as reference nps and
-    # 0.7 Mnps as threshold for the slow worker.
+    
+    # Value from running bench on 32 processes on Ryzen 9 7950X
     # also set in rundb.py and delta_update_users.py
-    factor = 136622 / base_nps
+    factor = 368174 / base_nps
 
     # Adjust CPU scaling.
     _, tc_limit_ltc = adjust_tc("60+0.6", factor)

--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 0, "updater.py": "gSJX/HbsPwsZnUZaFbAgF0zwWPWXv+LEw9jBhJkxFOrCH9CZS0+4U4nE2fJdeNze", "worker.py": "Z/vtaJrdh55/HCfEmnWYvcuSweJ1M2SEXf0pVi3s5j+kt5Tp8celr/twvi7mbvnZ", "games.py": "97ypvSiVwHgOi4XLas8ZQBIRXSuxwKXVipXEH3KRTgcEKsDosTtvz14kk2fZsrOs"}
+{"__version": 0, "updater.py": "gSJX/HbsPwsZnUZaFbAgF0zwWPWXv+LEw9jBhJkxFOrCH9CZS0+4U4nE2fJdeNze", "worker.py": "Z/vtaJrdh55/HCfEmnWYvcuSweJ1M2SEXf0pVi3s5j+kt5Tp8celr/twvi7mbvnZ", "games.py": "yI3zWUrXaXsO8Gnv8IKMSWUDNbE2NgYxlb8bG5diIseTE70R+OOjjgWWrh1+TmvP"}


### PR DESCRIPTION
The bench normalization script was run on 32 processes on 2 seperate Ryzen 9 7950X systems using https://github.com/official-monty/Monty/commit/a59c6a56e349156bf4218c4dcf3c9bad2453a273. The average NPS (over the minute interval) was 368174.
The slow worker threshold is set at a third of this: 122725

Note: Running on a Ryzen 5 3600 1 process: SF16.1 gets 1200799 NPS and Monty gets 420853 NPS. https://github.com/official-stockfish/fishtest/pull/1900 Comparing the ratio to the 691680 NPS here we can see:

Our unit of time is 73% longer than the Stockfish fishtest instance.

Bench normalization script: https://github.com/official-monty/montytools/blob/main/BenchNormalization/benchNormToolMonty.py