### PR TITLE
Set out Monty testing procedure

### DIFF
--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -811,7 +811,7 @@ class RunDb:
                     nps += concurrency * task["worker_info"]["nps"]
                     if task["worker_info"]["nps"] != 0:
                         games_per_minute += (
-                            (task["worker_info"]["nps"] / 368174)
+                            (task["worker_info"]["nps"] / 184087)
                             * (60.0 / estimate_game_duration(run["args"]["tc"]))
                             * (
                                 int(task["worker_info"]["concurrency"])

--- a/server/fishtest/templates/tests_run.mak
+++ b/server/fishtest/templates/tests_run.mak
@@ -59,11 +59,11 @@
                     <input class="list-group-item-check pe-none" type="radio" name="test-type" id="stc_test"
                       data-options='{
                         "name": "STC",
-                        "tc": "10+0.1",
-                        "new_tc": "10+0.1",
+                        "tc": "20+0.2",
+                        "new_tc": "20+0.2",
                         "throughput": "100",
                         "threads": 1,
-                        "options": "Hash=16",
+                        "options": "Hash=32",
                         "book": "${test_book}",
                         "stop_rule": "stop-rule-sprt",
                         "bounds": "standard STC",
@@ -80,11 +80,11 @@
                     <input class="list-group-item-check pe-none" type="radio" name="test-type" id="ltc_test"
                       data-options='{
                         "name": "LTC",
-                        "tc": "60+0.6",
-                        "new_tc": "60+0.6",
+                        "tc": "120+1.2",
+                        "new_tc": "120+1.2",
                         "throughput": "100",
                         "threads": 1,
-                        "options": "Hash=64",
+                        "options": "Hash=128",
                         "book": "${test_book}",
                         "stop_rule": "stop-rule-sprt",
                         "bounds": "standard LTC"
@@ -98,11 +98,11 @@
                     <input class="list-group-item-check pe-none" type="radio" name="test-type" id="stc_smp_test"
                       data-options='{
                         "name": "STC SMP",
-                        "tc": "5+0.05",
-                        "new_tc": "5+0.05",
+                        "tc": "6+0.06",
+                        "new_tc": "6+0.06",
                         "throughput": "100",
-                        "threads": 8,
-                        "options": "Hash=64",
+                        "threads": 15,
+                        "options": "Hash=128",
                         "book": "${test_book}",
                         "stop_rule": "stop-rule-sprt",
                         "bounds": "standard STC"
@@ -116,11 +116,11 @@
                     <input class="list-group-item-check pe-none" type="radio" name="test-type" id="ltc_smp_test"
                       data-options='{
                         "name": "LTC SMP",
-                        "tc": "20+0.2",
-                        "new_tc": "20+0.2",
+                        "tc": "24+0.24",
+                        "new_tc": "24+0.24",
                         "throughput": "100",
-                        "threads": 8,
-                        "options": "Hash=256",
+                        "threads": 15,
+                        "options": "Hash=512",
                         "book": "${test_book}",
                         "stop_rule": "stop-rule-sprt",
                         "bounds": "standard LTC"
@@ -134,11 +134,11 @@
                     <input class="list-group-item-check pe-none" type="radio" name="test-type" id="vltc_test"
                       data-options='{
                         "name": "VLTC",
-                        "tc": "180+1.8",
-                        "new_tc": "180+1.8",
+                        "tc": "120+1.2",
+                        "new_tc": "120+1.2",
                         "throughput": "50",
-                        "threads": 1,
-                        "options": "Hash=192",
+                        "threads": 3,
+                        "options": "Hash=384",
                         "book": "${test_book}",
                         "stop_rule": "stop-rule-sprt",
                         "bounds": "standard STC"
@@ -152,10 +152,10 @@
                     <input class="list-group-item-check pe-none" type="radio" name="test-type" id="vltc_smp_test"
                       data-options='{
                         "name": "VLTC SMP",
-                        "tc": "60+0.6",
-                        "new_tc": "60+0.6",
+                        "tc": "200+2",
+                        "new_tc": "200+2",
                         "throughput": "50",
-                        "threads": 8,
+                        "threads": 5,
                         "options": "Hash=512",
                         "book": "${test_book}",
                         "stop_rule": "stop-rule-sprt",
@@ -170,11 +170,11 @@
                     <input class="list-group-item-check pe-none" type="radio" name="test-type" id="pt_test"
                       data-options='{
                         "name": "PT",
-                        "tc": "60+0.6",
-                        "new_tc": "60+0.6",
+                        "tc": "120+1.2",
+                        "new_tc": "120+1.2",
                         "throughput": "100",
                         "threads": 1,
-                        "options": "Hash=64",
+                        "options": "Hash=128",
                         "book": "${pt_book}",
                         "stop_rule": "stop-rule-games",
                         "games": 60000,
@@ -192,11 +192,11 @@
                     <input class="list-group-item-check pe-none" type="radio" name="test-type" id="pt_smp_test"
                       data-options='{
                         "name": "PT SMP",
-                        "tc": "60+0.6",
-                        "new_tc": "60+0.6",
+                        "tc": "200+2",
+                        "new_tc": "200+2",
                         "throughput": "100",
-                        "threads": 8,
-                        "options": "Hash=512",
+                        "threads": 5,
+                        "options": "Hash=1024",
                         "book": "${pt_book}",
                         "stop_rule": "stop-rule-games",
                         "games": 60000,
@@ -368,10 +368,10 @@
                 <div class="col-12 col-md">
                   <label for="bounds" class="form-label">SPRT Bounds</label>
                   <select class="form-select" id="bounds" name="bounds">
-                    <option value="standard STC">Standard STC ${fb(0.0, 2.0)}</option>
-                    <option value="standard LTC">Standard LTC ${fb(0.5, 2.5)}</option>
-                    <option value="regression STC">Non-regression STC ${fb(-1.75, 0.25)}</option>
-                    <option value="regression LTC">Non-regression LTC ${fb(-1.75, 0.25)}</option>
+                    <option value="standard STC">Standard STC ${fb(0.0, 4.0)}</option>
+                    <option value="standard LTC">Standard LTC ${fb(1.0, 5.0)}</option>
+                    <option value="regression STC">Non-regression STC ${fb(-3.5, 0.5)}</option>
+                    <option value="regression LTC">Non-regression LTC ${fb(-3.5, 0.5)}</option>
                     <option value="custom" ${'selected' if is_rerun else ''}>Custom bounds...</option>
                   </select>
                 </div>

--- a/server/utils/delta_update_users.py
+++ b/server/utils/delta_update_users.py
@@ -48,7 +48,7 @@ def compute_games_rates(rundb, info_tuple):
     # use the reference core nps, also set in rundb.py and games.py
     for machine in rundb.get_machines():
         games_per_hour = (
-            (machine["nps"] / 368174)
+            (machine["nps"] / 184087)
             * (3600.0 / estimate_game_duration(machine["run"]["args"]["tc"]))
             * (int(machine["concurrency"]) // machine["run"]["args"].get("threads", 1))
         )

--- a/worker/games.py
+++ b/worker/games.py
@@ -472,7 +472,7 @@ def setup_engine(
         shutil.copyfile(testing_dir / policyfile, policyfile)
 
         cmd = [
-            "make",
+            "make montytest",
             f"EXE={destination}",
             f"EVALFILE={evalfile}",
             f"POLICYFILE={policyfile}",

--- a/worker/games.py
+++ b/worker/games.py
@@ -1140,7 +1140,7 @@ def run_games(
     if run_errors:
         raise RunException("\n".join(run_errors))
 
-    if base_nps < 122725 / (1 + math.tanh((worker_concurrency - 1) / 8)):
+    if base_nps < 61362 / (1 + math.tanh((worker_concurrency - 1) / 8)):
         raise FatalException(
             "This machine is too slow ({} nps / thread) to run fishtest effectively - sorry!".format(
                 base_nps
@@ -1149,7 +1149,7 @@ def run_games(
     
     # Value from running bench on 32 processes on Ryzen 9 7950X
     # also set in rundb.py and delta_update_users.py
-    factor = 368174 / base_nps
+    factor = 184087 / base_nps
 
     # Adjust CPU scaling.
     _, tc_limit_ltc = adjust_tc("60+0.6", factor)

--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 0, "updater.py": "gSJX/HbsPwsZnUZaFbAgF0zwWPWXv+LEw9jBhJkxFOrCH9CZS0+4U4nE2fJdeNze", "worker.py": "AHkb6WdPSB83Qjg5Mbv+ljmYw7H/qaFtOnbgA7kHW7/b435sgNPYOAAJIGGXpPQO", "games.py": "2SqO13KEwDnp2vKrptKYRzhJyFQCSTjRK7F2bLRGU4ZLFdfFoAR3XnWk5vBphxOX"}
+{"__version": 0, "updater.py": "gSJX/HbsPwsZnUZaFbAgF0zwWPWXv+LEw9jBhJkxFOrCH9CZS0+4U4nE2fJdeNze", "worker.py": "AHkb6WdPSB83Qjg5Mbv+ljmYw7H/qaFtOnbgA7kHW7/b435sgNPYOAAJIGGXpPQO", "games.py": "e7OU4HK/VNxhIrQb+NeupOBCEFP3cq7paPabNHCD7yONkemBUeMdaIFBcTwZDkAd"}

--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 0, "updater.py": "gSJX/HbsPwsZnUZaFbAgF0zwWPWXv+LEw9jBhJkxFOrCH9CZS0+4U4nE2fJdeNze", "worker.py": "AHkb6WdPSB83Qjg5Mbv+ljmYw7H/qaFtOnbgA7kHW7/b435sgNPYOAAJIGGXpPQO", "games.py": "e7OU4HK/VNxhIrQb+NeupOBCEFP3cq7paPabNHCD7yONkemBUeMdaIFBcTwZDkAd"}
+{"__version": 0, "updater.py": "gSJX/HbsPwsZnUZaFbAgF0zwWPWXv+LEw9jBhJkxFOrCH9CZS0+4U4nE2fJdeNze", "worker.py": "AHkb6WdPSB83Qjg5Mbv+ljmYw7H/qaFtOnbgA7kHW7/b435sgNPYOAAJIGGXpPQO", "games.py": "vxgYHFpdJgYyqt1ogiau3fBPX+i1mywNEfIBwlDKqYxFGe8FdREWoSfXLR3DlAzg"}

--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 0, "updater.py": "gSJX/HbsPwsZnUZaFbAgF0zwWPWXv+LEw9jBhJkxFOrCH9CZS0+4U4nE2fJdeNze", "worker.py": "AHkb6WdPSB83Qjg5Mbv+ljmYw7H/qaFtOnbgA7kHW7/b435sgNPYOAAJIGGXpPQO", "games.py": "oHlVURT/rFR/UpdBHs/PJ39rGcsQcvlY08IzKIopYq4B2KZWPWM5YLLdy3GnP+jn"}
+{"__version": 0, "updater.py": "gSJX/HbsPwsZnUZaFbAgF0zwWPWXv+LEw9jBhJkxFOrCH9CZS0+4U4nE2fJdeNze", "worker.py": "AHkb6WdPSB83Qjg5Mbv+ljmYw7H/qaFtOnbgA7kHW7/b435sgNPYOAAJIGGXpPQO", "games.py": "l0o340nc0wZr+kIy/8BA9ZIXH9kWIYF+CW0lJi39VreSFpgx1WQLdzUQslTLbeQc"}


### PR DESCRIPTION
This commit:

Applies a factor of 2 division to the Ryzen 7950X benchmark nps to more closely resemble the fleet average nps, which is on average EPYCs from a few generations ago. It also makes the reference nps close to the Stockfish fishtest instance.

Sets out the standard testing TCs. These are set double the Stockfish fishtest instance to account for the likely additional scaling behaviour present in MCTS. TCs above LTC are set to use threads in order to reduce hash requirements, but will only be usable once SMP is added.

The hash ratio is maintained equal to the Stockfish fishtest instance. I.E. it has been doubled with the TC.

The SPRT elo0, elo1 gap has been doubled but the midpoint is equal to the Stockfish fishtest instance. This doubles the threshold elo to pass and quarters the required games (approximately), corresponding to Monty's earlier stage of development.